### PR TITLE
Fix last label

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedUnitRanges"
 uuid = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/gradedunitrange.jl
+++ b/src/gradedunitrange.jl
@@ -73,7 +73,9 @@ function BlockArrays.blockedrange(lblocklengths::AbstractVector{<:LabelledIntege
   return gradedrange(lblocklengths)
 end
 
-Base.last(a::AbstractGradedUnitRange) = isempty(a.lasts) ? first(a) - 1 : last(a.lasts)
+function Base.last(a::AbstractGradedUnitRange)
+  return isempty(a.lasts) ? labelled(first(a) - 1, label(first(a))) : last(a.lasts)
+end
 
 function gradedrange(lblocklengths::AbstractVector{<:Pair{<:Any,<:Integer}})
   return gradedrange(labelled.(last.(lblocklengths), first.(lblocklengths)))


### PR DESCRIPTION
This PR fixes a lost label in `last`. The lost label triggered a type unstability which is now fixed. However, I have not been able to add a test for this case. No function allows to create an `AbstractUnitRange` with empty `lasts`. It can still be initialized explicitly, but it has many issues (`first` crashes), preventing testing.

Maybe we should just return `last(a.lasts)` and accept a crash for empty `a.lasts` (which is still the current behavior)?