### PR TITLE
Preserve dual when taking axes of dual unit range

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedUnitRanges"
 uuid = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/gradedunitrangedual.jl
+++ b/src/gradedunitrangedual.jl
@@ -118,7 +118,7 @@ function dual_axes(v::BlockVector)
   return mortar(dual.(blocks(v)), block_axes)
 end
 
-Base.axes(a::GradedUnitRangeDual) = axes(nondual(a))
+Base.axes(a::GradedUnitRangeDual) = dual.(axes(nondual(a)))
 
 function BlockArrays.BlockSlice(b::Block, a::LabelledUnitRange)
   return BlockSlice(b, unlabel(a))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,8 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 LabelledNumbers = "f856a3a6-4152-4ec4-b2a7-02c1a55d7993"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_dual.jl
+++ b/test/test_dual.jl
@@ -187,6 +187,7 @@ end
     @test nondual_type(a) === typeof(a)
 
     @test isdual(ad)
+    @test isdual(only(axes(ad)))
     @test !isdual(a)
     @test axes(Base.Slice(a)) isa Tuple{typeof(a)}
     @test AbstractUnitRange{Int}(ad) == 1:5


### PR DESCRIPTION
@ogauthe I see this was defined in https://github.com/ITensor/GradedUnitRanges.jl/commit/ad73f5b254df5953cb685af7c79a5ebbd057a9cc, I think it makes sense to preserve the dual information.

A common code pattern where this would be used is slicing with a graded unit range, where the new array will inherit the graded unit ranges of the slice. In those cases this new definition will help preserve the dual information.