### PR TITLE
Define `dag(::AbstractArray)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedUnitRanges"
 uuid = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,7 @@ makedocs(;
     edit_link="main",
     assets=String[],
   ),
-  pages=["Home" => "index.md"],
+  pages=["Home" => "index.md", "Reference" => "reference.md"],
 )
 
 deploydocs(;

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,5 @@
+# Reference
+
+```@autodocs
+Modules = [GradedUnitRanges]
+```

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -1,7 +1,14 @@
 using LabelledNumbers: LabelledInteger, label, labelled, unlabel
 
-# default behavior: any object is self-dual
+"""
+    dual(x)
+
+Take the dual of the symmetry sector, graded unit range, etc.
+By default, it just returns `x`, i.e. it assumes the object
+is self-dual.
+"""
 dual(x) = x
+
 nondual(r::AbstractUnitRange) = r
 isdual(::AbstractUnitRange) = false
 
@@ -12,3 +19,22 @@ nondual_type(T::Type) = T
 
 dual(i::LabelledInteger) = labelled(unlabel(i), dual(label(i)))
 flip(a::AbstractUnitRange) = dual(map_blocklabels(dual, a))
+
+"""
+    dag(r::AbstractUnitRange)
+
+Same as `dual(r)`.
+"""
+dag(r::AbstractUnitRange) = dual(r)
+
+"""
+    dag(a::AbstractArray)
+
+Complex conjugates `a` and takes the dual of the axes.
+"""
+function dag(a::AbstractArray)
+  # TODO: Fix `similar(a, dual.(axes(a)))`.
+  a′ = similar(a, dual.(axes(a)))
+  a′ .= conj.(a)
+  return a′
+end

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -33,7 +33,6 @@ dag(r::AbstractUnitRange) = dual(r)
 Complex conjugates `a` and takes the dual of the axes.
 """
 function dag(a::AbstractArray)
-  # TODO: Fix `similar(a, dual.(axes(a)))`.
   a′ = similar(a, dual.(axes(a)))
   a′ .= conj.(a)
   return a′

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+BlockSparseArrays = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 LabelledNumbers = "f856a3a6-4152-4ec4-b2a7-02c1a55d7993"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"


### PR DESCRIPTION
This PR introduces `dag(a::AbstractArray)`, which complex conjugates the elements of `a`, and additionally take the `dual` of the axes (if the axes are self-dual, it does nothing to the axes).

This also defines `dag(r::AbstractUnitRange) = dual(r)`, since that is the syntax in ITensors.jl for taking the dual of a QN Index. I don't like having two names for that, but I think it is consistent with the more general definition `dag(a::AbstractArray)` (from the perspective that the axis of a range is a one-based version of itself). It makes me think that it would be nicer to just replace `dag` with `dual` so I'm opening this up for discussion.

@emstoudenmire @lkdvos @ogauthe

Todo:
- [x] Add tests.
- [x] ~~Decide if it is better to call get rid of `dag` and just use `dual`.~~ This requires more discussion so I think I'll keep the current design for now and we can revisit the names later.