### PR TITLE
specialize `unmerged_tensor_product` for `OneToOne`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedUnitRanges"
 uuid = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -21,6 +21,7 @@ unmerged_tensor_product() = OneToOne()
 unmerged_tensor_product(a) = a
 unmerged_tensor_product(a, ::OneToOne) = a
 unmerged_tensor_product(::OneToOne, a) = a
+unmerged_tensor_product(::OneToOne, ::OneToOne) = OneToOne()
 unmerged_tensor_product(a1, a2) = tensor_product(a1, a2)
 function unmerged_tensor_product(a1, a2, as...)
   return unmerged_tensor_product(unmerged_tensor_product(a1, a2), as...)

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -19,6 +19,8 @@ end
 
 unmerged_tensor_product() = OneToOne()
 unmerged_tensor_product(a) = a
+unmerged_tensor_product(a, ::OneToOne) = a
+unmerged_tensor_product(::OneToOne, a) = a
 unmerged_tensor_product(a1, a2) = tensor_product(a1, a2)
 function unmerged_tensor_product(a1, a2, as...)
   return unmerged_tensor_product(unmerged_tensor_product(a1, a2), as...)

--- a/test/test_tensor_product.jl
+++ b/test/test_tensor_product.jl
@@ -62,6 +62,9 @@ end
 
 @testset "symmetric tensor_product" begin
   for a in (a0, a0[1:5])
+    @test labelled_isequal(unmerged_tensor_product(a), a)
+    @test labelled_isequal(unmerged_tensor_product(a, OneToOne()), a)
+    @test labelled_isequal(unmerged_tensor_product(OneToOne(), a), a)
     @test labelled_isequal(tensor_product(a), gradedrange([U1(1) => 2, U1(2) => 3]))
 
     @test labelled_isequal(
@@ -88,6 +91,8 @@ end
     b = unmerged_tensor_product(ad)
     @test isdual(b)
     @test space_isequal(b, ad)
+    @test space_isequal(unmerged_tensor_product(ad, OneToOne()), ad)
+    @test space_isequal(unmerged_tensor_product(OneToOne(), ad), ad)
 
     b = tensor_product(ad)
     @test b isa GradedOneTo

--- a/test/test_tensor_product.jl
+++ b/test/test_tensor_product.jl
@@ -27,6 +27,7 @@ a0 = gradedrange([U1(1) => 1, U1(2) => 3, U1(1) => 1])
   GradedUnitRanges.fuse_labels(x::String, y::String) = x * y
 
   @test unmerged_tensor_product() isa OneToOne
+  @test unmerged_tensor_product(OneToOne(), OneToOne()) isa OneToOne
 
   a = gradedrange(["x" => 2, "y" => 3])
   @test labelled_isequal(unmerged_tensor_product(a), a)


### PR DESCRIPTION
This PR makes `OneToOne` a neutral element for `unmerged_tensor_product`. It now preserves blocks and dual.

This is required to use it in `BlockSparseArrays`, at least until systematic use of `BlockedTuple` is implemented.